### PR TITLE
adding support for s3 to sns events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,5 +137,5 @@ dmypy.json
 
 #IDE
 .idea
-
+.DS_Store
 tools

--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ The module has three variants of notification delivery:
 
 All three variants of notification delivery support separating notifications into different Slack channels or SNS topics based on event account ID.
 
+## S3 to SNS to Lambda Flow
+
+The module supports two event flow patterns:
+
+1. **Direct S3 to Lambda** (default): S3 bucket notifications directly invoke the Lambda function
+2. **S3 to SNS to Lambda**: S3 bucket notifications are sent to an SNS topic, which then triggers the Lambda function
+
+The S3 to SNS to Lambda flow provides additional benefits:
+- Multiple subscribers can receive the same S3 events
+- Better support for fan-out patterns
+- Easier cross-account event processing
+- Additional filtering and routing capabilities via SNS
+
+To enable S3 to SNS to Lambda flow, set `enable_s3_sns_notifications = true`. See the [S3 SNS configuration example](https://github.com/fivexl/terraform-aws-cloudtrail-to-slack/blob/master/examples/s3_sns_configuration/main.tf) for details.
+
 # Rules
 
 Rules are python strings that are evaluated in the runtime and should return the bool value, if rule returns True, then notification will be sent to Slack.

--- a/examples/s3_sns_configuration/README.md
+++ b/examples/s3_sns_configuration/README.md
@@ -1,0 +1,90 @@
+# S3 to SNS to Lambda Configuration Example
+
+This example demonstrates how to configure the CloudTrail to Slack module to use SNS as an intermediary between S3 and Lambda, instead of direct S3 to Lambda invocation.
+
+## Architecture
+
+```
+S3 Bucket (CloudTrail logs) -> SNS Topic -> Lambda Function -> Slack
+```
+
+## Why use SNS?
+
+Using SNS as an intermediary provides several benefits:
+
+1. **Multiple Subscribers**: You can have multiple Lambda functions or other services subscribe to the same S3 events
+2. **Fan-out Pattern**: Distribute S3 events to multiple destinations
+3. **Better Control**: SNS provides additional filtering and routing capabilities
+4. **Cross-Account**: Easier to handle cross-account scenarios
+5. **Decoupling**: Better separation of concerns between S3 events and processing
+
+## Usage
+
+```hcl
+module "cloudtrail_to_slack_with_sns" {
+  source = "fivexl/cloudtrail-to-slack/aws"
+
+  function_name                   = "cloudtrail-to-slack-sns"
+  cloudtrail_logs_s3_bucket_name  = "my-cloudtrail-logs-bucket"
+  cloudtrail_logs_kms_key_id      = "alias/my-cloudtrail-kms-key"
+
+  # Enable S3 to SNS to Lambda flow
+  enable_s3_sns_notifications     = true
+  
+  # Optional: specify custom SNS topic name
+  s3_sns_topic_name               = "cloudtrail-s3-notifications"
+
+  # Slack configuration
+  slack_bot_token                 = var.slack_bot_token
+  default_slack_channel_id        = var.default_slack_channel_id
+
+  # Other configurations...
+}
+```
+
+## Using an Existing SNS Topic
+
+If you already have an SNS topic configured for S3 notifications:
+
+```hcl
+module "cloudtrail_to_slack_with_existing_sns" {
+  source = "fivexl/cloudtrail-to-slack/aws"
+
+  function_name                   = "cloudtrail-to-slack-sns"
+  cloudtrail_logs_s3_bucket_name  = "my-cloudtrail-logs-bucket"
+  cloudtrail_logs_kms_key_id      = "alias/my-cloudtrail-kms-key"
+
+  # Enable S3 to SNS to Lambda flow with existing topic
+  enable_s3_sns_notifications     = true
+  s3_sns_topic_arn                = "arn:aws:sns:us-east-1:123456789012:existing-topic"
+
+  # Slack configuration
+  slack_bot_token                 = var.slack_bot_token
+  default_slack_channel_id        = var.default_slack_channel_id
+
+  # Other configurations...
+}
+```
+
+## Important Notes
+
+- When `enable_s3_sns_notifications` is set to `true`, the module will NOT create a direct S3 to Lambda notification
+- The Lambda function is automatically updated to handle both direct S3 events and SNS-wrapped S3 events
+- If `s3_sns_topic_arn` is provided, the module will use that existing topic; otherwise, it will create a new one
+- The S3 bucket notification will be configured to send events to SNS instead of directly to Lambda
+
+## Variables
+
+| Name | Description | Type | Required |
+|------|-------------|------|----------|
+| `enable_s3_sns_notifications` | Whether to enable S3 to SNS to Lambda flow | `bool` | No (default: `false`) |
+| `s3_sns_topic_name` | Name of the SNS topic for S3 bucket notifications | `string` | No |
+| `s3_sns_topic_arn` | ARN of existing SNS topic for S3 bucket notifications | `string` | No |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `lambda_function_arn` | The ARN of the Lambda Function |
+| `s3_sns_topic_arn` | The ARN of the SNS topic for S3 notifications |
+| `s3_sns_topic_name` | The name of the SNS topic for S3 notifications |

--- a/examples/s3_sns_configuration/main.tf
+++ b/examples/s3_sns_configuration/main.tf
@@ -1,0 +1,52 @@
+# Example configuration for S3 to SNS to Lambda flow
+# This example shows how to enable S3 notifications via SNS
+
+module "cloudtrail_to_slack_with_sns" {
+  source = "fivexl/cloudtrail-to-slack/aws"
+
+  function_name                  = "cloudtrail-to-slack-sns-example"
+  cloudtrail_logs_s3_bucket_name = "my-cloudtrail-logs-bucket"
+  cloudtrail_logs_kms_key_id     = "alias/my-cloudtrail-kms-key"
+
+  # Enable S3 to SNS to Lambda flow
+  enable_s3_sns_notifications = true
+  # Optional: specify custom SNS topic name (if not provided, will use function_name-s3-notifications)
+  s3_sns_topic_name = "cloudtrail-s3-notifications"
+
+  # Slack configuration
+  slack_bot_token          = var.slack_bot_token
+  default_slack_channel_id = var.default_slack_channel_id
+
+  # DynamoDB configuration for thread grouping
+  dynamodb_table_name   = "cloudtrail-to-slack-events"
+  dynamodb_time_to_live = 900
+
+  # Rules configuration
+  use_default_rules = true
+  rules             = ""
+  ignore_rules      = ""
+
+  tags = {
+    Environment = "production"
+    ManagedBy   = "terraform"
+  }
+}
+
+# Alternatively, if you want to use an existing SNS topic:
+# module "cloudtrail_to_slack_with_existing_sns" {
+#   source                         = "fivexl/cloudtrail-to-slack/aws"
+#
+#   function_name                   = "cloudtrail-to-slack-sns-example"
+#   cloudtrail_logs_s3_bucket_name  = "my-cloudtrail-logs-bucket"
+#   cloudtrail_logs_kms_key_id      = "alias/my-cloudtrail-kms-key"
+#
+#   # Enable S3 to SNS to Lambda flow with existing topic
+#   enable_s3_sns_notifications     = true
+#   s3_sns_topic_arn                = "arn:aws:sns:us-east-1:123456789012:existing-topic"
+#
+#   # Slack configuration
+#   slack_bot_token                 = var.slack_bot_token
+#   default_slack_channel_id        = var.default_slack_channel_id
+#
+#   # Other configurations...
+# }

--- a/examples/s3_sns_configuration/outputs.tf
+++ b/examples/s3_sns_configuration/outputs.tf
@@ -1,0 +1,14 @@
+output "lambda_function_arn" {
+  description = "The ARN of the Lambda Function"
+  value       = module.cloudtrail_to_slack_with_sns.lambda_function_arn
+}
+
+output "s3_sns_topic_arn" {
+  description = "The ARN of the SNS topic for S3 notifications"
+  value       = module.cloudtrail_to_slack_with_sns.s3_sns_topic_arn
+}
+
+output "s3_sns_topic_name" {
+  description = "The name of the SNS topic for S3 notifications"
+  value       = module.cloudtrail_to_slack_with_sns.s3_sns_topic_name
+}

--- a/examples/s3_sns_configuration/variables.tf
+++ b/examples/s3_sns_configuration/variables.tf
@@ -1,0 +1,10 @@
+variable "slack_bot_token" {
+  description = "The Slack bot token used for sending messages to Slack"
+  type        = string
+  sensitive   = true
+}
+
+variable "default_slack_channel_id" {
+  description = "The default Slack channel ID to send notifications to"
+  type        = string
+}

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ data "aws_iam_policy_document" "s3" {
       "dynamodb:GetItem",
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.dynamodb_table_name}"
+      "arn:${data.aws_partition.current.partition}:dynamodb:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:table/${var.dynamodb_table_name}"
     ]
   }
   statement {

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ module "lambda" {
   function_name = var.function_name
   description   = "Send CloudTrail Events to Slack"
   handler       = "main.lambda_handler"
-  runtime       = "python3.10"
+  runtime       = "python3.13"
   timeout       = var.lambda_timeout_seconds
   publish       = true
 
@@ -25,7 +25,7 @@ module "lambda" {
     }
   ]
 
-  docker_image             = "lambda/python:3.10"
+  docker_image             = "lambda/python:3.13"
   docker_file              = "${path.module}/src/docker/Dockerfile"
   recreate_missing_package = var.lambda_recreate_missing_package
   build_in_docker          = var.lambda_build_in_docker
@@ -178,7 +178,7 @@ resource "aws_lambda_permission" "s3" {
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
-  count  = var.create_bucket_notification ? 1 : 0
+  count  = var.create_bucket_notification && !var.enable_s3_sns_notifications ? 1 : 0
   bucket = data.aws_s3_bucket.cloudtrail.id
 
   lambda_function {
@@ -192,6 +192,24 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
 
   depends_on = [aws_lambda_permission.s3]
 }
+
+# S3 Bucket Notification to SNS
+resource "aws_s3_bucket_notification" "bucket_notification_sns" {
+  count  = var.enable_s3_sns_notifications && var.create_bucket_notification ? 1 : 0
+  bucket = data.aws_s3_bucket.cloudtrail.id
+
+  topic {
+    topic_arn     = var.s3_sns_topic_arn != null ? var.s3_sns_topic_arn : aws_sns_topic.s3_notifications[0].arn
+    events        = var.s3_removed_object_notification ? ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"] : ["s3:ObjectCreated:*"]
+    filter_prefix = var.s3_notification_filter_prefix
+    filter_suffix = ".json.gz"
+  }
+
+  eventbridge = var.enable_eventbridge_notificaitons
+
+  depends_on = [aws_sns_topic_policy.s3_notifications]
+}
+
 
 moved {
   from = aws_s3_bucket_notification.bucket_notification

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,13 @@ output "lambda_function_arn" {
   description = "The ARN of the Lambda Function"
   value       = module.lambda.lambda_function_arn
 }
+
+output "s3_sns_topic_arn" {
+  description = "The ARN of the SNS topic for S3 notifications (if created)"
+  value       = var.enable_s3_sns_notifications && var.s3_sns_topic_arn == null ? aws_sns_topic.s3_notifications[0].arn : var.s3_sns_topic_arn
+}
+
+output "s3_sns_topic_name" {
+  description = "The name of the SNS topic for S3 notifications (if created)"
+  value       = var.enable_s3_sns_notifications && var.s3_sns_topic_arn == null ? aws_sns_topic.s3_notifications[0].name : null
+}

--- a/s3_sns.tf
+++ b/s3_sns.tf
@@ -1,0 +1,67 @@
+# SNS Topic for S3 bucket notifications
+resource "aws_sns_topic" "s3_notifications" {
+  count = var.enable_s3_sns_notifications && var.s3_sns_topic_arn == null ? 1 : 0
+  name  = var.s3_sns_topic_name != null ? var.s3_sns_topic_name : "${var.function_name}-s3-notifications"
+  tags  = var.tags
+}
+
+# SNS Topic Policy to allow S3 to publish
+resource "aws_sns_topic_policy" "s3_notifications" {
+  count  = var.enable_s3_sns_notifications && var.s3_sns_topic_arn == null ? 1 : 0
+  arn    = aws_sns_topic.s3_notifications[0].arn
+  policy = data.aws_iam_policy_document.s3_sns_topic_policy[0].json
+}
+
+data "aws_iam_policy_document" "s3_sns_topic_policy" {
+  count = var.enable_s3_sns_notifications && var.s3_sns_topic_arn == null ? 1 : 0
+
+  statement {
+    sid    = "AllowS3ToPublish"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+
+    actions = [
+      "SNS:Publish",
+    ]
+
+    resources = [
+      aws_sns_topic.s3_notifications[0].arn,
+    ]
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = [data.aws_s3_bucket.cloudtrail.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}
+
+# Lambda Permission for SNS to invoke Lambda
+resource "aws_lambda_permission" "sns" {
+  count         = var.enable_s3_sns_notifications ? 1 : 0
+  statement_id  = "AllowExecutionFromSNS"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda.lambda_function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = var.s3_sns_topic_arn != null ? var.s3_sns_topic_arn : aws_sns_topic.s3_notifications[0].arn
+}
+
+# SNS Topic Subscription for Lambda
+resource "aws_sns_topic_subscription" "lambda" {
+  count     = var.enable_s3_sns_notifications ? 1 : 0
+  topic_arn = var.s3_sns_topic_arn != null ? var.s3_sns_topic_arn : aws_sns_topic.s3_notifications[0].arn
+  protocol  = "lambda"
+  endpoint  = module.lambda.lambda_function_arn
+
+  depends_on = [aws_lambda_permission.sns]
+}

--- a/setup.sh
+++ b/setup.sh
@@ -4,4 +4,4 @@
 
 python3 -m venv env
 source env/bin/activate
-pip install -r requirements.txt
+pip install -r src/requirements.txt

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -1,3 +1,3 @@
-FROM public.ecr.aws/lambda/python:3.10
+FROM public.ecr.aws/lambda/python:3.13
 
 RUN pip install poetry==1.2.2

--- a/src/slack_helpers.py
+++ b/src/slack_helpers.py
@@ -1,7 +1,7 @@
 import http.client
 import json
 
-from config import  get_logger, SlackAppConfig, SlackWebhookConfig
+from config import get_logger, SlackAppConfig, SlackWebhookConfig
 from dateutil.parser import parse as parse_date
 from slack_sdk import WebClient
 from typing import Any
@@ -10,57 +10,47 @@ from slack_sdk.web.slack_response import SlackResponse
 logger = get_logger()
 
 
-
-def post_message( # noqa: ANN201
-        slack_config: SlackAppConfig | SlackWebhookConfig,
-        message: dict,
-        account_id: str | None = None,
-        thread_ts: str | None = None,
+def post_message(  # noqa: ANN201
+    slack_config: SlackAppConfig | SlackWebhookConfig,
+    message: dict,
+    account_id: str | None = None,
+    thread_ts: str | None = None,
 ) -> None | SlackResponse:
 
     if isinstance(slack_config, SlackAppConfig):
         if account_id and slack_config.configuration:
             channel_id = next(
-                (cfg["slack_channel_id"] for cfg in slack_config.configuration if account_id in cfg["accounts"]), # noqa: E501
-                slack_config.default_channel_id
+                (cfg["slack_channel_id"] for cfg in slack_config.configuration if account_id in cfg["accounts"]),  # noqa: E501
+                slack_config.default_channel_id,
             )
         else:
             channel_id = slack_config.default_channel_id
         return slack_app_post_message(
-            message = message,
-            channel_id = channel_id,
-            slack_config = slack_config,
-            thread_ts = thread_ts,
+            message=message,
+            channel_id=channel_id,
+            slack_config=slack_config,
+            thread_ts=thread_ts,
         )
 
     if isinstance(slack_config, SlackWebhookConfig):
         if account_id and slack_config.configuration:
             hook_url = next(
-                (cfg["slack_hook_url"] for cfg in slack_config.configuration if account_id in cfg["accounts"]), # noqa: E501
-                slack_config.default_hook_url
+                (cfg["slack_hook_url"] for cfg in slack_config.configuration if account_id in cfg["accounts"]),  # noqa: E501
+                slack_config.default_hook_url,
             )
         else:
             hook_url = slack_config.default_hook_url
         webhook_post_message(
-            message = message,
-            hook_url = hook_url,
+            message=message,
+            hook_url=hook_url,
         )
 
 
-def slack_app_post_message( # noqa: ANN201
-        message: dict,
-        channel_id: str,
-        slack_config: SlackAppConfig,
-        thread_ts: str | None = None
-):
+def slack_app_post_message(message: dict, channel_id: str, slack_config: SlackAppConfig, thread_ts: str | None = None):  # noqa: ANN201
     client = WebClient(token=slack_config.bot_token)
     return client.chat_postMessage(
-        channel = channel_id,
-        blocks = message["blocks"],
-        thread_ts = thread_ts,
-        text="New message from CloudTrailToSlack"
+        channel=channel_id, blocks=message["blocks"], thread_ts=thread_ts, text="New message from CloudTrailToSlack"
     )
-
 
 
 # Slack web hook example
@@ -69,17 +59,14 @@ def webhook_post_message(message: dict, hook_url: str) -> int:
     logger.info({"Sending message to slack": message})
     headers = {"Content-type": "application/json"}
     connection = http.client.HTTPSConnection("hooks.slack.com")
-    connection.request("POST",
-                       hook_url.replace("https://hooks.slack.com", ""),
-                       json.dumps(message),
-                       headers)
+    connection.request("POST", hook_url.replace("https://hooks.slack.com", ""), json.dumps(message), headers)
     response = connection.getresponse()
     logger.info({"Slack response": {"status": response.status, "message": response.read().decode()}})
     return response.status
 
 
 # Format message
-def event_to_slack_message(event:  dict, source_file :str , account_id_from_event: str ) ->  dict[str, Any]:
+def event_to_slack_message(event: dict, source_file: str, account_id_from_event: str) -> dict[str, Any]:
     event_name = event["eventName"]
     error_code = event.get("errorCode")
     error_message = event.get("errorMessage")
@@ -95,80 +82,32 @@ def event_to_slack_message(event:  dict, source_file :str , account_id_from_even
     blocks = []
     contexts = []
 
-    blocks.append(
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": title
-            }
-        }
-    )
+    blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": title}})
 
     if error_message is not None:
-        blocks.append(
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"*Error message:* ```{error_message}```"
-                }
-            }
-        )
+        blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": f"*Error message:* ```{error_message}```"}})
 
     if event_name == "ConsoleLogin" and event["additionalEventData"]["MFAUsed"] != "Yes":
-        blocks.append(
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": ":warning: *Login without MFA!* :warning:"
-                }
-            }
-        )
+        blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": ":warning: *Login without MFA!* :warning:"}})
 
     if request_parameters is not None:
-        contexts.append({
-            "type": "mrkdwn",
-            "text": f"*requestParameters:* ```{json.dumps(request_parameters, indent=4)}```"
-        })
+        contexts.append({"type": "mrkdwn", "text": f"*requestParameters:* ```{json.dumps(request_parameters, indent=4)}```"})
 
     if response_elements is not None:
-        contexts.append({
-            "type": "mrkdwn",
-            "text": f"*responseElements:* ```{json.dumps(response_elements, indent=4)}```"
-        })
+        contexts.append({"type": "mrkdwn", "text": f"*responseElements:* ```{json.dumps(response_elements, indent=4)}```"})
 
     if additional_details is not None:
-        contexts.append({
-            "type": "mrkdwn",
-            "text": f"*additionalEventData:* ```{json.dumps(additional_details, indent=4)}```"
-        })
+        contexts.append({"type": "mrkdwn", "text": f"*additionalEventData:* ```{json.dumps(additional_details, indent=4)}```"})
 
-    contexts.append({
-        "type": "mrkdwn",
-        "text": f"Time: {event_time} UTC"
-    })
+    contexts.append({"type": "mrkdwn", "text": f"Time: {event_time} UTC"})
 
-    contexts.append({
-        "type": "mrkdwn",
-        "text": f"Id: {event_id}"
-    })
+    contexts.append({"type": "mrkdwn", "text": f"Id: {event_id}"})
 
-    contexts.append({
-        "type": "mrkdwn",
-        "text": f"Account Id: {account_id_from_event}"
-    })
+    contexts.append({"type": "mrkdwn", "text": f"Account Id: {account_id_from_event}"})
 
-    contexts.append({
-        "type": "mrkdwn",
-        "text": f"Event location in s3:\n{source_file}"
-    })
+    contexts.append({"type": "mrkdwn", "text": f"Event location in s3:\n{source_file}"})
 
-    blocks.append({
-        "type": "context",
-        "elements": contexts
-    })
+    blocks.append({"type": "context", "elements": contexts})
 
     blocks.append({"type": "divider"})
 
@@ -177,10 +116,7 @@ def event_to_slack_message(event:  dict, source_file :str , account_id_from_even
     return message
 
 
-def message_for_slack_error_notification(
-        error: Exception,
-        s3_notification_event:  dict
-) ->  dict:
+def message_for_slack_error_notification(error: Exception, s3_notification_event: dict) -> dict:
     object_keys = [record["s3"]["object"]["key"] for record in s3_notification_event["Records"]]
     if len(object_keys) == 1:
         object_key = object_keys[0]
@@ -189,93 +125,24 @@ def message_for_slack_error_notification(
 
     title = ":warning: *Failed to process event:*  :warning:"
     blocks = [
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": title
-            }
-        },
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": "*Error:*"
-            }
-        },
-        {
-            "type": "context",
-            "elements": [
-                {
-                    "type": "mrkdwn",
-                    "text": f"```{error}```"
-                }
-            ]
-        },
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": "*Object(s):*"
-            }
-        },
-        {
-            "type": "context",
-            "elements": [
-                {
-                    "type": "mrkdwn",
-                    "text": f"{object_key}"
-                }
-            ]
-        }
+        {"type": "section", "text": {"type": "mrkdwn", "text": title}},
+        {"type": "section", "text": {"type": "mrkdwn", "text": "*Error:*"}},
+        {"type": "context", "elements": [{"type": "mrkdwn", "text": f"```{error}```"}]},
+        {"type": "section", "text": {"type": "mrkdwn", "text": "*Object(s):*"}},
+        {"type": "context", "elements": [{"type": "mrkdwn", "text": f"{object_key}"}]},
     ]
     message = {"blocks": blocks}
 
     return message
 
 
-def message_for_rule_evaluation_error_notification(
-        error: Exception,
-        object_key: str,
-        rule: str
-) ->  dict[str, Any]:
+def message_for_rule_evaluation_error_notification(error: Exception, object_key: str, rule: str) -> dict[str, Any]:
     title = ":warning: *Failed to evaluate rule:*  :warning:"
     blocks = [
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": title
-            }
-        },
-        {
-            "type": "context",
-            "elements": [
-                {
-                    "type": "mrkdwn",
-                    "text": f"*Rule:* \n```{rule}```"
-                }
-            ]
-        },
-
-        {
-            "type": "context",
-            "elements": [
-                {
-                    "type": "mrkdwn",
-                    "text": f"*Error:* \n```{error}```"
-                }
-            ]
-        },
-        {
-            "type": "context",
-            "elements": [
-                {
-                    "type": "mrkdwn",
-                    "text": f"*Object:* \n{object_key}"
-                }
-            ]
-        }
+        {"type": "section", "text": {"type": "mrkdwn", "text": title}},
+        {"type": "context", "elements": [{"type": "mrkdwn", "text": f"*Rule:* \n```{rule}```"}]},
+        {"type": "context", "elements": [{"type": "mrkdwn", "text": f"*Error:* \n```{error}```"}]},
+        {"type": "context", "elements": [{"type": "mrkdwn", "text": f"*Object:* \n{object_key}"}]},
     ]
     message = {"blocks": blocks}
 

--- a/src/tests/test_events.json
+++ b/src/tests/test_events.json
@@ -270,7 +270,7 @@
         },
         {
             "test_event_name": "UpdateFunctionCode",
-            "event":{
+            "event": {
                 "eventVersion": "1.08",
                 "userIdentitytype": "AssumedRole",
                 "userIdentity": {
@@ -280,16 +280,16 @@
                     "accessKeyId": "-",
                     "sessionContext": {
                         "sessionIssuer": {
-                                "type": "Role",
-                                "principalId": "-",
-                                "arn": "--",
-                                "accountId": "-",
-                                "userName": "-"
-                            },
-                            "attributes": {
-                                "creationDate": "2023-07-03T18:07:02Z",
-                                "mfaAuthenticated": "false"
-                            }
+                            "type": "Role",
+                            "principalId": "-",
+                            "arn": "--",
+                            "accountId": "-",
+                            "userName": "-"
+                        },
+                        "attributes": {
+                            "creationDate": "2023-07-03T18:07:02Z",
+                            "mfaAuthenticated": "false"
+                        }
                     }
                 },
                 "eventTime": "2000-01-03T16:14:51Z",
@@ -316,7 +316,7 @@
                 "responseElements": {
                     "functionName": "fivexl-cloudtrail-to-slack",
                     "functionArn": "-k",
-                    "runtime": "python3.10",
+                    "runtime": "python3.13",
                     "role": "arn:aws:iam::-:role/fivexl-cloudtrail-to-slack",
                     "handler": "main.lambda_handler",
                     "codeSize": 23383731,
@@ -335,8 +335,12 @@
                     "lastUpdateStatusReason": "The function is being created.",
                     "lastUpdateStatusReasonCode": "Creating",
                     "packageType": "Zip",
-                    "architectures": {"0": "x86_64"},
-                    "ephemeralStorage": {"size": 512},
+                    "architectures": {
+                        "0": "x86_64"
+                    },
+                    "ephemeralStorage": {
+                        "size": 512
+                    },
                     "snapStart": {
                         "applyOn": "None",
                         "optimizationStatus": "Off"
@@ -398,7 +402,7 @@
                 "responseElements": {
                     "functionName": "fivexl-cloudtrail-to-slack",
                     "functionArn": "-",
-                    "runtime": "python3.10",
+                    "runtime": "python3.13",
                     "role": "-",
                     "handler": "main.lambda_handler",
                     "codeSize": 23564916,
@@ -443,4 +447,3 @@
         }
     ]
 }
-

--- a/src/tests/test_message_processing.py
+++ b/src/tests/test_message_processing.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from main import ProcessingResult, should_message_be_processed
+from main import ProcessingResult, should_message_be_processed, extract_s3_records_from_event
 from rules import default_rules
 
 # ruff: noqa: ANN201, ANN001, E501
@@ -14,48 +14,41 @@ with open("tests/test_events.json") as f:
     data = json.load(f)
 
 
-@pytest.fixture(
-    params = data["test_events"],
-    ids = [event["test_event_name"] for event in data["test_events"]]
-)
+@pytest.fixture(params=data["test_events"], ids=[event["test_event_name"] for event in data["test_events"]])
 def message_should_be_processed_test_cases(request):
     return request.param
 
 
 @pytest.fixture(
-    params = [
+    params=[
         {
             "in": {
-                "event":{
-                    "userIdentity": "123",
-                    "eventName": "empty_event",
-                    "eventSource": "imagination"
-                },
+                "event": {"userIdentity": "123", "eventName": "empty_event", "eventSource": "imagination"},
             },
             "out": {
                 "result": ProcessingResult(False, []),
             },
         },
     ],
-    ids = ["empty_event"],
+    ids=["empty_event"],
 )
 def message_should_not_be_processed_test_cases(request):
     return request.param
 
 
 @pytest.fixture(
-    params = [
+    params=[
         {
             "in": {
                 "incorrect_rule": "incorrect_rule",
-                "event":{
+                "event": {
                     "eventVersion": "1.05",
                     "userIdentity": {
                         "type": "IAMUser",
                         "principalId": "XXXXXXXXXXX",
                         "arn": "arn:aws:iam::XXXXXXXXXXX:user/xxxxxxxx",
                         "accountId": "XXXXXXXXXXX",
-                        "userName": "xxxxxxxx"
+                        "userName": "xxxxxxxx",
                     },
                     "eventTime": "2019-07-03T16:14:51Z",
                     "eventSource": "signin.amazonaws.com",
@@ -64,62 +57,53 @@ def message_should_not_be_processed_test_cases(request):
                     "sourceIPAddress": "83.41.208.104",
                     "userAgent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:67.0) Gecko/20100101 Firefox/67.0",
                     "requestParameters": "null",
-                    "responseElements": {
-                        "ConsoleLogin": "Success"
-                    },
+                    "responseElements": {"ConsoleLogin": "Success"},
                     "additionalEventData": {
                         "LoginTo": "https://console.aws.amazon.com/ec2/v2/home?XXXXXXXXXXX",
                         "MobileVersion": "No",
-                        "MFAUsed": "No"
+                        "MFAUsed": "No",
                     },
                     "eventID": "0e4d136e-25d4-4d92-b2b2-8a9fe1e3f1af",
                     "eventType": "AwsConsoleSignIn",
-                    "recipientAccountId": "XXXXXXXXXXX"
+                    "recipientAccountId": "XXXXXXXXXXX",
                 },
             },
             "out": {
-                "result": ProcessingResult(should_be_processed=True, errors=[{"error": NameError("name 'incorrect_rule' is not defined"), "rule": "incorrect_rule"}]),
+                "result": ProcessingResult(
+                    should_be_processed=True,
+                    errors=[{"error": NameError("name 'incorrect_rule' is not defined"), "rule": "incorrect_rule"}],
+                ),
             },
         },
     ],
-    ids= ["incorrect_rule"],
+    ids=["incorrect_rule"],
 )
 def message_should_be_processed_with_incorrect_rule_test_case(request):
     return request.param
 
 
-
 def test_message_should_be_processed(message_should_be_processed_test_cases) -> None:
     assert should_message_be_processed(
-        event = message_should_be_processed_test_cases["event"],
-        rules = default_rules,
-        ignore_rules = []
-        ) == ProcessingResult(should_be_processed=True, errors=[])
+        event=message_should_be_processed_test_cases["event"], rules=default_rules, ignore_rules=[]
+    ) == ProcessingResult(should_be_processed=True, errors=[])
 
 
 def test_message_should_not_be_processed(message_should_not_be_processed_test_cases) -> None:
-    assert should_message_be_processed(
-        event = message_should_not_be_processed_test_cases["in"]["event"],
-        rules = default_rules,
-        ignore_rules = []
-        ) == message_should_not_be_processed_test_cases["out"]["result"]
+    assert (
+        should_message_be_processed(event=message_should_not_be_processed_test_cases["in"]["event"], rules=default_rules, ignore_rules=[])
+        == message_should_not_be_processed_test_cases["out"]["result"]
+    )
 
 
 def test_message_should_not_be_processed_with_rules_as_ignor_rules(message_should_be_processed_test_cases) -> None:
     assert should_message_be_processed(
-        event = message_should_be_processed_test_cases["event"],
-        rules = default_rules,
-        ignore_rules = default_rules
-        ) == ProcessingResult(should_be_processed=False, errors=[], is_ignored=True)
+        event=message_should_be_processed_test_cases["event"], rules=default_rules, ignore_rules=default_rules
+    ) == ProcessingResult(should_be_processed=False, errors=[], is_ignored=True)
 
 
-def test_should_message_be_processed_with_ParsingEventError_handling(
-    message_should_be_processed_with_incorrect_rule_test_case
-) -> None:
+def test_should_message_be_processed_with_ParsingEventError_handling(message_should_be_processed_with_incorrect_rule_test_case) -> None:
     almost_default_rules = default_rules.copy()
-    almost_default_rules.insert(
-        0, message_should_be_processed_with_incorrect_rule_test_case["in"]["incorrect_rule"]
-    )
+    almost_default_rules.insert(0, message_should_be_processed_with_incorrect_rule_test_case["in"]["incorrect_rule"])
     result = should_message_be_processed(
         event=message_should_be_processed_with_incorrect_rule_test_case["in"]["event"],
         rules=almost_default_rules,  # type: ignore # noqa:
@@ -130,5 +114,100 @@ def test_should_message_be_processed_with_ParsingEventError_handling(
     assert result.should_be_processed == message_should_be_processed_with_incorrect_rule_test_case["out"]["result"].should_be_processed
 
     # compare error messages in the result
-    assert str(result.errors[0]["error"]) == str(message_should_be_processed_with_incorrect_rule_test_case["out"]["result"].errors[0]["error"])
+    assert str(result.errors[0]["error"]) == str(
+        message_should_be_processed_with_incorrect_rule_test_case["out"]["result"].errors[0]["error"]
+    )
     assert result.errors[0]["rule"] == message_should_be_processed_with_incorrect_rule_test_case["out"]["result"].errors[0]["rule"]
+
+
+def test_extract_s3_records_from_direct_s3_event() -> None:
+    """Test extracting S3 records from a direct S3 event."""
+    direct_s3_event = {
+        "Records": [
+            {
+                "eventSource": "aws:s3",
+                "eventName": "ObjectCreated:Put",
+                "s3": {"bucket": {"name": "test-bucket"}, "object": {"key": "test-key.json.gz"}},
+            }
+        ]
+    }
+
+    records = extract_s3_records_from_event(direct_s3_event)
+
+    assert len(records) == 1
+    assert records[0]["eventSource"] == "aws:s3"
+    assert records[0]["eventName"] == "ObjectCreated:Put"
+
+
+def test_extract_s3_records_from_sns_wrapped_event() -> None:
+    """Test extracting S3 records from an SNS-wrapped S3 event."""
+    sns_wrapped_event = {
+        "Records": [
+            {
+                "EventSource": "aws:sns",
+                "Sns": {
+                    "Message": json.dumps(
+                        {
+                            "Records": [
+                                {
+                                    "eventSource": "aws:s3",
+                                    "eventName": "ObjectCreated:Put",
+                                    "s3": {"bucket": {"name": "test-bucket"}, "object": {"key": "test-key.json.gz"}},
+                                }
+                            ]
+                        }
+                    )
+                },
+            }
+        ]
+    }
+
+    records = extract_s3_records_from_event(sns_wrapped_event)
+
+    assert len(records) == 1
+    assert records[0]["eventSource"] == "aws:s3"
+    assert records[0]["eventName"] == "ObjectCreated:Put"
+
+
+def test_extract_s3_records_from_multiple_sns_records() -> None:
+    """Test extracting S3 records from multiple SNS records."""
+    sns_wrapped_event = {
+        "Records": [
+            {
+                "EventSource": "aws:sns",
+                "Sns": {
+                    "Message": json.dumps(
+                        {
+                            "Records": [
+                                {
+                                    "eventSource": "aws:s3",
+                                    "eventName": "ObjectCreated:Put",
+                                    "s3": {"bucket": {"name": "test-bucket"}, "object": {"key": "key1.json.gz"}},
+                                },
+                                {
+                                    "eventSource": "aws:s3",
+                                    "eventName": "ObjectCreated:Copy",
+                                    "s3": {"bucket": {"name": "test-bucket"}, "object": {"key": "key2.json.gz"}},
+                                },
+                            ]
+                        }
+                    )
+                },
+            }
+        ]
+    }
+
+    records = extract_s3_records_from_event(sns_wrapped_event)
+
+    assert len(records) == 2
+    assert records[0]["eventName"] == "ObjectCreated:Put"
+    assert records[1]["eventName"] == "ObjectCreated:Copy"
+
+
+def test_extract_s3_records_empty_event() -> None:
+    """Test handling of event without Records."""
+    empty_event = {}
+
+    records = extract_s3_records_from_event(empty_event)
+
+    assert len(records) == 0

--- a/src/tests/test_sns_event.json
+++ b/src/tests/test_sns_event.json
@@ -1,0 +1,22 @@
+{
+    "Records": [
+        {
+            "EventSource": "aws:sns",
+            "EventVersion": "1.0",
+            "EventSubscriptionArn": "arn:aws:sns:us-east-1:123456789012:s3-notifications:12345678-1234-1234-1234-123456789012",
+            "Sns": {
+                "Type": "Notification",
+                "MessageId": "12345678-1234-1234-1234-123456789012",
+                "TopicArn": "arn:aws:sns:us-east-1:123456789012:s3-notifications",
+                "Subject": "Amazon S3 Notification",
+                "Message": "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-east-1\",\"eventTime\":\"2026-01-19T12:00:00.000Z\",\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AWS:AIDAI123456789EXAMPLE\"},\"requestParameters\":{\"sourceIPAddress\":\"192.0.2.1\"},\"responseElements\":{\"x-amz-request-id\":\"ABC123DEF456\",\"x-amz-id-2\":\"example-id-2\"},\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"test-config\",\"bucket\":{\"name\":\"my-cloudtrail-bucket\",\"ownerIdentity\":{\"principalId\":\"A1234567890123\"},\"arn\":\"arn:aws:s3:::my-cloudtrail-bucket\"},\"object\":{\"key\":\"AWSLogs/123456789012/CloudTrail/us-east-1/2026/01/19/123456789012_CloudTrail_us-east-1_20260119T1200Z_abc123.json.gz\",\"size\":1024,\"eTag\":\"abc123def456\",\"sequencer\":\"00ABC123DEF456\"}}}]}",
+                "Timestamp": "2026-01-19T12:00:00.000Z",
+                "SignatureVersion": "1",
+                "Signature": "example-signature",
+                "SigningCertUrl": "https://sns.us-east-1.amazonaws.com/cert.pem",
+                "UnsubscribeUrl": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:123456789012:s3-notifications:12345678-1234-1234-1234-123456789012",
+                "MessageAttributes": {}
+            }
+        }
+    ]
+}

--- a/vars.tf
+++ b/vars.tf
@@ -228,3 +228,21 @@ variable "enable_eventbridge_notificaitons" {
   default     = false
   type        = bool
 }
+
+variable "enable_s3_sns_notifications" {
+  description = "Whether to enable S3 to SNS to Lambda flow. If true, S3 bucket will send notifications to SNS topic, which will trigger Lambda"
+  default     = false
+  type        = bool
+}
+
+variable "s3_sns_topic_name" {
+  description = "Name of the SNS topic for S3 bucket notifications. Only used if enable_s3_sns_notifications is true"
+  default     = null
+  type        = string
+}
+
+variable "s3_sns_topic_arn" {
+  description = "ARN of existing SNS topic for S3 bucket notifications. If not provided and enable_s3_sns_notifications is true, a new topic will be created"
+  default     = null
+  type        = string
+}


### PR DESCRIPTION
The S3 to SNS to Lambda flow provides additional benefits:
- Multiple subscribers can receive the same S3 events
- Better support for fan-out patterns
- Easier cross-account event processing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an SNS intermediary for S3 notifications and upgrades the Lambda runtime.
> 
> - **New option:** `enable_s3_sns_notifications` with `s3_sns_topic_name`/`s3_sns_topic_arn` to route S3 events via SNS
> - **Terraform:** Creates `aws_sns_topic`, policy, subscription, and conditional `aws_s3_bucket_notification` to SNS; disables direct S3→Lambda when enabled; adds outputs `s3_sns_topic_arn` and `s3_sns_topic_name`
> - **Lambda runtime:** Bumps to `python3.13` and Docker base `lambda/python:3.13`; fixes DynamoDB ARN to use `data.aws_region.current.id`
> - **Event handling:** Adds `extract_s3_records_from_event` to process SNS-wrapped S3 events; updates handler; adds unit tests and SNS event fixtures
> - **Docs/examples:** README section on S3→SNS→Lambda; new `examples/s3_sns_configuration` (usage, variables, outputs)
> - **Misc:** Update `.gitignore` and `setup.sh` requirements path
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eea357df7e06a19d57f5a92639fc9ac33d2d20b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->