### PR TITLE
fix: replace eval() with a restricted rule evaluator, patch click/urllib3 CVEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,43 @@ For detailed documentation and examples, see:
 
 Rules are python strings that are evaluated in the runtime and should return the bool value, if rule returns True, then notification will be sent to Slack.
 
+Rules are **not** executed with Python's `eval()`. They are parsed and evaluated
+by a restricted expression evaluator ([`src/rule_evaluator.py`](src/rule_evaluator.py))
+that only permits the boolean-expression subset of Python listed below, so a rule
+can never import a module, read an attribute, or run arbitrary code (CWE-94).
+
+Supported in a rule:
+
+| Feature | Example |
+| --- | --- |
+| Key lookup | `event["eventName"]` |
+| `dict` helpers | `event.get("errorCode", "")`, `len(event.keys())`, `"x" in event` |
+| String helpers | `.startswith(...)`, `.endswith(...)`, `.lower()`, `.split(...)`, `.replace(...)`, `.strip()` |
+| Comparisons | `==`, `!=`, `<`, `<=`, `>`, `>=`, `is`, `is not` |
+| Membership | `in`, `not in` |
+| Boolean logic | `and`, `or`, `not`, parentheses, ternary `a if c else b` |
+| Literals | strings, numbers, `True` / `False` / `None`, tuples, lists, sets, dicts |
+| Arithmetic | `+`, `-`, `/`, `//`, `%` |
+| Slicing | `event["userIdentity.arn"][:12]` |
+| Builtins | `abs`, `all`, `any`, `bool`, `float`, `int`, `len`, `max`, `min`, `round`, `sorted`, `str`, `sum` |
+
+Not supported, and rejected with a rule evaluation error:
+
+- attribute access other than the methods above (so `event.__class__` and friends are unreachable)
+- comprehensions, generator expressions, `lambda`, f-strings, `:=`
+- `**` and `*`, the bitwise and shift operators (`& | ^ << >> ~`) — `**` and `*`
+  let a one-line rule exhaust the function's memory, and an out-of-memory kill
+  cannot be reported as a per-rule error the way an exception can
+- any call to a function that is not one of the builtins listed above
+- rules longer than 65536 characters, larger than 2000 expression elements, or
+  nested more than 100 levels deep
+
+If you are upgrading and a rule stops matching, check the rule evaluation errors
+(they are sent to Slack unless `rule_evaluation_errors_to_slack` is `false`) and
+rewrite the rule using the grammar above. Every rule ever shipped or documented
+by this module — subscripts, `.get`, `.startswith` / `.endswith`, `in`, `and`,
+`not` — works unchanged.
+
 This module comes with a set of predefined rules (default rules) that users can take advantage of:
 
 ## Default rules:

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,14 @@ module "lambda" {
         "!tests/.*",
         "!tools/.*",
         "!.pytest_cache/.*",
+        "!\\.ruff_cache/.*",
+        # Development dependency manifests must not ship inside the artifact.
+        # Only deploy_requirements.txt is installed at build time, but a
+        # scanner (e.g. Amazon Inspector) that finds these files in the zip
+        # reports the whole dev tool chain as Lambda runtime dependencies.
+        "!pyproject\\.toml",
+        "!poetry\\.lock",
+        "!requirements\\.txt",
       ]
     }
   ]

--- a/src/main.py
+++ b/src/main.py
@@ -24,6 +24,7 @@ from slack_sdk.web.slack_response import SlackResponse
 
 from config import Config, SlackAppConfig, SlackWebhookConfig, get_logger, get_slack_config
 from dynamodb import get_thread_ts_from_dynamodb, put_event_to_dynamodb
+from rule_evaluator import evaluate_rule
 from slack_helpers import (
     event_to_slack_message,
     message_for_rule_evaluation_error_notification,
@@ -183,7 +184,7 @@ def should_message_be_processed(
     errors = []
     for ignore_rule in ignore_rules:
         try:
-            if eval(ignore_rule, {}, {"event": flat_event}) is True:  # noqa: PGH001
+            if evaluate_rule(ignore_rule, flat_event) is True:
                 logger.info(
                     {"Event matched ignore rule and will not be processed": {"ignore_rule": ignore_rule, "flat_event": flat_event}}
                 )  # noqa: E501
@@ -194,7 +195,7 @@ def should_message_be_processed(
 
     for rule in rules:
         try:
-            if eval(rule, {}, {"event": flat_event}) is True:  # noqa: PGH001
+            if evaluate_rule(rule, flat_event) is True:
                 logger.info({"Event matched rule and will be processed": {"rule": rule, "flat_event": flat_event}})  # noqa: E501
                 return ProcessingResult(True, errors)
         except Exception as e:

--- a/src/poetry.lock
+++ b/src/poetry.lock
@@ -93,14 +93,14 @@ crt = ["awscrt (==0.23.4)"]
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.4.2"
 description = "Composable command line interface toolkit"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
-    {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
+    {file = "click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"},
+    {file = "click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6"},
 ]
 
 [package.dependencies]
@@ -383,23 +383,23 @@ optional = ["SQLAlchemy (>=1.4,<3)", "aiodns (>1.0)", "aiohttp (>=3.7.3,<4)", "b
 
 [[package]]
 name = "urllib3"
-version = "2.3.0"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
-    {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\""]
+brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.14"
-content-hash = "8cdab407fda2581d9e00039d2b9ec22573a8b3549d8bf948e300dc4ad2f1ca86"
+content-hash = "45dffb9a8b108e7a24de432b22745a0abc4c4b3f6e2f6b9c4e8cd4f79e13d30a"

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -18,6 +18,13 @@ black = "^26.5.1"
 boto3 = "^1.26.97"
 ruff = "^0.15.0"
 slack-sdk = "^3.21.3"
+# Transitive dependencies pinned to their patched versions so the exported
+# lockfiles do not ship known-vulnerable versions:
+#   click   - CVE-2026-7246 (command injection in click.edit), fixed in 8.3.3
+#   urllib3 - CVE-2025-66418, CVE-2025-66471, CVE-2026-21441 (decompression
+#             bombs / unbounded decompression chains), all fixed by 2.6.3
+click = ">=8.3.3"
+urllib3 = ">=2.6.3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -32,9 +32,9 @@ boto3==1.36.0 ; python_version >= "3.14" and python_version < "4.0" \
 botocore==1.36.0 ; python_version >= "3.14" and python_version < "4.0" \
     --hash=sha256:0232029ff9ae3f5b50cdb25cbd257c16f87402b6d31a05bd6483638ee6434c4b \
     --hash=sha256:b54b11f0cfc47fc1243ada0f7f461266c279968487616720fa8ebb02183917d7
-click==8.1.8 ; python_version >= "3.14" and python_version < "4.0" \
-    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
-    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
+click==8.4.2 ; python_version >= "3.14" and python_version < "4.0" \
+    --hash=sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6 \
+    --hash=sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76
 colorama==0.4.6 ; python_version >= "3.14" and python_version < "4.0" and (sys_platform == "win32" or platform_system == "Windows") \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
@@ -136,6 +136,6 @@ six==1.17.0 ; python_version >= "3.14" and python_version < "4.0" \
 slack-sdk==3.34.0 ; python_version >= "3.14" and python_version < "4.0" \
     --hash=sha256:c61f57f310d85be83466db5a98ab6ae3bb2e5587437b54fa0daa8fae6a0feffa \
     --hash=sha256:ff61db7012160eed742285ea91f11c72b7a38a6500a7f6c5335662b4bc6b853d
-urllib3==2.3.0 ; python_version >= "3.14" and python_version < "4.0" \
-    --hash=sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df \
-    --hash=sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d
+urllib3==2.7.0 ; python_version >= "3.14" and python_version < "4.0" \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897

--- a/src/rule_evaluator.py
+++ b/src/rule_evaluator.py
@@ -1,0 +1,460 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Restricted evaluator for CloudTrail-to-Slack rule expressions.
+
+Rules are operator-supplied Python-like boolean expressions (see the "Rules"
+section of the README). They used to be handed to the builtin ``eval()``, which
+executes arbitrary Python: anything able to influence the ``RULES`` /
+``IGNORE_RULES`` Lambda environment variables could run code inside the function
+(CWE-94). ``eval`` also cannot be locked down by passing empty globals, because
+CPython injects ``__builtins__`` automatically, leaving
+``__import__("os").system(...)`` reachable.
+
+This module instead parses each rule with :mod:`ast` and walks the tree with an
+explicit allow-list of node types, operators, builtins, and method names. There
+is no code path that imports a module, accesses an attribute that is not a
+white-listed method call, reads a dunder, assigns, or calls anything other than
+the small set of pure builtins below - so a rule cannot escape the expression
+language regardless of what it contains.
+
+The supported grammar covers everything the documented rules use:
+
+* ``event["key"]`` and ``event.get("key", "default")``
+* string helpers such as ``.startswith((...))`` / ``.endswith((...))``
+* comparisons, ``in`` / ``not in``, ``and`` / ``or`` / ``not``, ternaries
+* literals (str, numbers, bools, ``None``, tuple/list/set/dict) and slicing
+* the pure builtins in :data:`_ALLOWED_BUILTINS`
+
+Anything else raises :class:`UnsupportedRuleError`, which the caller reports the
+same way it already reports a malformed rule.
+
+Note that this is a sandbox for a *configuration* language, not a defence against
+a hostile tenant: anything able to set ``RULES`` can already replace the function
+code. Its purpose is to make the documented rule syntax evaluable without
+handing the rule string to the interpreter.
+"""
+
+import ast
+from typing import Any, Callable, Dict, Tuple
+
+# Guard rails against pathological rule strings.
+#
+# The length limit only exists to stop an absurd input reaching the parser: it
+# has to stay well clear of a legitimate rule, because config.py folds an entire
+# ``events_to_track`` list into a single expression. ``MAX_NESTING_DEPTH`` is the
+# limit that actually matters, since evaluation recurses once per nesting level.
+MAX_EXPRESSION_LENGTH = 65536
+MAX_AST_NODES = 2000
+MAX_NESTING_DEPTH = 100
+
+# Pure, side-effect-free builtins. Deliberately excludes anything that can
+# import, open, execute, or reach the object graph (``getattr``, ``vars``,
+# ``type``, ``eval``, ``__import__`` ...).
+_ALLOWED_BUILTINS: Dict[str, Callable[..., Any]] = {
+    "abs": abs,
+    "all": all,
+    "any": any,
+    "bool": bool,
+    "float": float,
+    "int": int,
+    "len": len,
+    "max": max,
+    "min": min,
+    "round": round,
+    "sorted": sorted,
+    "str": str,
+    "sum": sum,
+}
+
+# Method names callable on a value produced by the expression itself (the
+# flattened event dict, a literal, or the result of an allowed builtin). Because
+# attribute *access* is never allowed on its own, and every name here is a
+# method of the JSON-ish types a flattened CloudTrail event can hold, none of
+# these can return a callable that widens the sandbox. ``format`` /
+# ``format_map`` are excluded on purpose: format strings can traverse
+# attributes (``"{0.__class__}".format(x)``).
+_ALLOWED_METHODS = frozenset(
+    {
+        # dict
+        "get",
+        "items",
+        "keys",
+        "values",
+        # str
+        "casefold",
+        "count",
+        "endswith",
+        "find",
+        "index",
+        "isalnum",
+        "isalpha",
+        "isdigit",
+        "islower",
+        "isnumeric",
+        "isupper",
+        "join",
+        "lower",
+        "lstrip",
+        "removeprefix",
+        "removesuffix",
+        "replace",
+        "rfind",
+        "rsplit",
+        "rstrip",
+        "split",
+        "splitlines",
+        "startswith",
+        "strip",
+        "title",
+        "upper",
+    }
+)
+
+_ALLOWED_BOOL_OPS = (ast.And, ast.Or)
+_ALLOWED_UNARY_OPS = (ast.Not, ast.UAdd, ast.USub)
+# ``Pow`` and ``Mult`` are excluded because both make it trivial to exhaust the
+# function's memory or timeout from a 20-character rule (``10 ** 10 ** 10``,
+# ``"a" * 300000000``), and an out-of-memory kill takes down the whole
+# invocation instead of being reported as a single rule error. The bitwise and
+# shift operators are excluded because no rule has any use for them.
+_ALLOWED_BIN_OPS = (ast.Add, ast.Sub, ast.Div, ast.FloorDiv, ast.Mod)
+_ALLOWED_COMPARE_OPS = (
+    ast.Eq,
+    ast.NotEq,
+    ast.Lt,
+    ast.LtE,
+    ast.Gt,
+    ast.GtE,
+    ast.In,
+    ast.NotIn,
+    ast.Is,
+    ast.IsNot,
+)
+_ALLOWED_CONSTANT_TYPES = (str, bytes, int, float, complex, bool, type(None))
+
+
+class RuleEvaluationError(Exception):
+    """Base class for problems found in a rule expression."""
+
+
+class UnsupportedRuleError(RuleEvaluationError):
+    """The rule uses syntax the restricted evaluator does not allow."""
+
+
+class RuleTooComplexError(RuleEvaluationError):
+    """The rule is longer / larger / more deeply nested than the limits allow."""
+
+
+class _RuleEvaluator:
+    """Evaluates a pre-validated rule AST against a set of bound names."""
+
+    def __init__(self, names: Dict[str, Any]) -> None:
+        self._names = names
+
+    def evaluate(self, node: ast.AST) -> Any:  # noqa: ANN401 (rules yield arbitrary JSON values)
+        handler = _HANDLERS.get(type(node))
+        if handler is None:
+            # Unreachable for a validated tree; kept so the evaluator fails
+            # closed if validation and evaluation ever drift apart.
+            raise UnsupportedRuleError(f"'{type(node).__name__}' is not allowed in a rule")
+        return handler(self, node)
+
+    def _eval_constant(self, node: ast.Constant) -> Any:  # noqa: ANN401
+        return node.value
+
+    def _eval_name(self, node: ast.Name) -> Any:  # noqa: ANN401
+        if node.id in self._names:
+            return self._names[node.id]
+        if node.id in _ALLOWED_BUILTINS:
+            return _ALLOWED_BUILTINS[node.id]
+        # Mirrors CPython's message so existing rule-error reporting is unchanged.
+        raise NameError(f"name '{node.id}' is not defined")
+
+    def _eval_bool_op(self, node: ast.BoolOp) -> Any:  # noqa: ANN401
+        if isinstance(node.op, ast.And):
+            result: Any = True
+            for value in node.values:
+                result = self.evaluate(value)
+                if not result:
+                    return result
+            return result
+        result = False
+        for value in node.values:
+            result = self.evaluate(value)
+            if result:
+                return result
+        return result
+
+    def _eval_unary_op(self, node: ast.UnaryOp) -> Any:  # noqa: ANN401
+        operand = self.evaluate(node.operand)
+        if isinstance(node.op, ast.Not):
+            return not operand
+        if isinstance(node.op, ast.USub):
+            return -operand
+        return +operand
+
+    def _eval_bin_op(self, node: ast.BinOp) -> Any:  # noqa: ANN401
+        left = self.evaluate(node.left)
+        right = self.evaluate(node.right)
+        return _BIN_OP_IMPLS[type(node.op)](left, right)
+
+    def _eval_compare(self, node: ast.Compare) -> Any:  # noqa: ANN401
+        left = self.evaluate(node.left)
+        result: Any = True
+        for operator, comparator_node in zip(node.ops, node.comparators, strict=True):
+            right = self.evaluate(comparator_node)
+            # Returning the comparison's own value (rather than a coerced bool)
+            # keeps parity with Python, which the caller's ``is True`` relies on.
+            result = _COMPARE_IMPLS[type(operator)](left, right)
+            if not result:
+                return result
+            left = right
+        return result
+
+    def _eval_if_exp(self, node: ast.IfExp) -> Any:  # noqa: ANN401
+        if self.evaluate(node.test):
+            return self.evaluate(node.body)
+        return self.evaluate(node.orelse)
+
+    def _eval_subscript(self, node: ast.Subscript) -> Any:  # noqa: ANN401
+        return self.evaluate(node.value)[self.evaluate(node.slice)]
+
+    def _eval_slice(self, node: ast.Slice) -> slice:
+        return slice(
+            None if node.lower is None else self.evaluate(node.lower),
+            None if node.upper is None else self.evaluate(node.upper),
+            None if node.step is None else self.evaluate(node.step),
+        )
+
+    def _eval_tuple(self, node: ast.Tuple) -> Tuple[Any, ...]:
+        return tuple(self.evaluate(element) for element in node.elts)
+
+    def _eval_list(self, node: ast.List) -> list:
+        return [self.evaluate(element) for element in node.elts]
+
+    def _eval_set(self, node: ast.Set) -> set:
+        return {self.evaluate(element) for element in node.elts}
+
+    def _eval_dict(self, node: ast.Dict) -> dict:
+        return {
+            self.evaluate(key): self.evaluate(value)
+            for key, value in zip(node.keys, node.values, strict=True)
+            if key is not None  # ``{**other}`` is rejected during validation
+        }
+
+    def _eval_call(self, node: ast.Call) -> Any:  # noqa: ANN401
+        args = [self.evaluate(arg) for arg in node.args]
+        kwargs = {keyword.arg: self.evaluate(keyword.value) for keyword in node.keywords if keyword.arg is not None}
+        if isinstance(node.func, ast.Attribute):
+            receiver = self.evaluate(node.func.value)
+            # Defence in depth: every name in ``_ALLOWED_METHODS`` is a method of
+            # a plain JSON-ish value, but a receiver can also be a type or a
+            # builtin carried in through a literal (``[str][0].upper("a")``).
+            # Refusing a callable receiver keeps an unbound method from ever
+            # being reachable, so adding a name to the allow-list later cannot
+            # accidentally widen the sandbox.
+            if isinstance(receiver, type) or callable(receiver):
+                raise UnsupportedRuleError(f"method '{node.func.attr}' cannot be called on a callable")
+            method = getattr(receiver, node.func.attr, None)
+            if method is None or not callable(method):
+                raise UnsupportedRuleError(f"'{type(receiver).__name__}' has no method '{node.func.attr}'")
+            return method(*args, **kwargs)
+        # Validation guarantees a bare call is a name bound to an allowed builtin.
+        return self.evaluate(node.func)(*args, **kwargs)
+
+
+_HANDLERS: Dict[type, Callable[[_RuleEvaluator, Any], Any]] = {
+    ast.Constant: _RuleEvaluator._eval_constant,
+    ast.Name: _RuleEvaluator._eval_name,
+    ast.BoolOp: _RuleEvaluator._eval_bool_op,
+    ast.UnaryOp: _RuleEvaluator._eval_unary_op,
+    ast.BinOp: _RuleEvaluator._eval_bin_op,
+    ast.Compare: _RuleEvaluator._eval_compare,
+    ast.IfExp: _RuleEvaluator._eval_if_exp,
+    ast.Subscript: _RuleEvaluator._eval_subscript,
+    ast.Slice: _RuleEvaluator._eval_slice,
+    ast.Tuple: _RuleEvaluator._eval_tuple,
+    ast.List: _RuleEvaluator._eval_list,
+    ast.Set: _RuleEvaluator._eval_set,
+    ast.Dict: _RuleEvaluator._eval_dict,
+    ast.Call: _RuleEvaluator._eval_call,
+}
+
+_BIN_OP_IMPLS: Dict[type, Callable[[Any, Any], Any]] = {
+    ast.Add: lambda left, right: left + right,
+    ast.Sub: lambda left, right: left - right,
+    ast.Mult: lambda left, right: left * right,
+    ast.Div: lambda left, right: left / right,
+    ast.FloorDiv: lambda left, right: left // right,
+    ast.Mod: lambda left, right: left % right,
+}
+
+_COMPARE_IMPLS: Dict[type, Callable[[Any, Any], Any]] = {
+    ast.Eq: lambda left, right: left == right,
+    ast.NotEq: lambda left, right: left != right,
+    ast.Lt: lambda left, right: left < right,
+    ast.LtE: lambda left, right: left <= right,
+    ast.Gt: lambda left, right: left > right,
+    ast.GtE: lambda left, right: left >= right,
+    ast.In: lambda left, right: left in right,
+    ast.NotIn: lambda left, right: left not in right,
+    ast.Is: lambda left, right: left is right,
+    ast.IsNot: lambda left, right: left is not right,
+}
+
+
+class _Budget:
+    """Counts validated nodes so a pathological rule cannot exhaust the Lambda."""
+
+    def __init__(self, limit: int) -> None:
+        self._remaining = limit
+        self._limit = limit
+
+    def consume(self) -> None:
+        self._remaining -= 1
+        if self._remaining < 0:
+            raise RuleTooComplexError(f"rule has more than {self._limit} expression elements")
+
+
+def _validate_node_details(node: ast.AST) -> None:
+    """Check the operators / constants a node carries as non-child attributes."""
+    if isinstance(node, ast.Constant) and not isinstance(node.value, _ALLOWED_CONSTANT_TYPES):
+        raise UnsupportedRuleError(f"constant of type '{type(node.value).__name__}' is not allowed in a rule")
+
+    if isinstance(node, ast.BoolOp) and not isinstance(node.op, _ALLOWED_BOOL_OPS):
+        raise UnsupportedRuleError(f"boolean operator '{type(node.op).__name__}' is not allowed in a rule")
+
+    if isinstance(node, ast.UnaryOp) and not isinstance(node.op, _ALLOWED_UNARY_OPS):
+        raise UnsupportedRuleError(f"unary operator '{type(node.op).__name__}' is not allowed in a rule")
+
+    if isinstance(node, ast.BinOp) and not isinstance(node.op, _ALLOWED_BIN_OPS):
+        raise UnsupportedRuleError(f"operator '{type(node.op).__name__}' is not allowed in a rule")
+
+    if isinstance(node, ast.Compare):
+        for operator in node.ops:
+            if not isinstance(operator, _ALLOWED_COMPARE_OPS):
+                raise UnsupportedRuleError(f"comparison '{type(operator).__name__}' is not allowed in a rule")
+
+    if isinstance(node, ast.Dict) and any(key is None for key in node.keys):
+        raise UnsupportedRuleError("dictionary unpacking is not allowed in a rule")
+
+
+def _validate(node: ast.AST, budget: _Budget, depth: int = 0) -> None:
+    """Recursively check that ``node`` only uses the allowed grammar.
+
+    Recursion is used rather than :func:`ast.walk` because an ``ast.Attribute``
+    is only acceptable in one position - as the callee of a call to an
+    allow-listed method - and a flat walk cannot see that context.
+    """
+    if depth > MAX_NESTING_DEPTH:
+        raise RuleTooComplexError(f"rule is nested more than {MAX_NESTING_DEPTH} levels deep")
+
+    node_type = type(node)
+    if node_type not in _HANDLERS:
+        raise UnsupportedRuleError(f"'{node_type.__name__}' is not allowed in a rule")
+    budget.consume()
+    _validate_node_details(node)
+
+    if isinstance(node, ast.Call):
+        _validate_call(node, budget, depth)
+        return
+
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.expr_context, ast.boolop, ast.operator, ast.unaryop, ast.cmpop)):
+            continue
+        _validate(child, budget, depth + 1)
+
+
+def _validate_call(node: ast.Call, budget: _Budget, depth: int) -> None:
+    if any(isinstance(arg, ast.Starred) for arg in node.args):
+        raise UnsupportedRuleError("argument unpacking is not allowed in a rule")
+    if any(keyword.arg is None for keyword in node.keywords):
+        raise UnsupportedRuleError("keyword argument unpacking is not allowed in a rule")
+
+    if isinstance(node.func, ast.Attribute):
+        attribute = node.func.attr
+        if attribute.startswith("_") or attribute not in _ALLOWED_METHODS:
+            raise UnsupportedRuleError(f"method '{attribute}' is not allowed in a rule")
+        budget.consume()
+        # The receiver is validated as an ordinary expression; the attribute
+        # itself is never evaluated as a standalone value.
+        _validate(node.func.value, budget, depth + 1)
+    elif isinstance(node.func, ast.Name):
+        if node.func.id not in _ALLOWED_BUILTINS:
+            raise UnsupportedRuleError(f"function '{node.func.id}' is not allowed in a rule")
+        budget.consume()
+    else:
+        raise UnsupportedRuleError("only calls to allowed builtins and allowed methods are permitted in a rule")
+
+    for arg in node.args:
+        _validate(arg, budget, depth + 1)
+    for keyword in node.keywords:
+        _validate(keyword.value, budget, depth + 1)
+
+
+# Rules are fixed for the lifetime of the Lambda container while
+# ``evaluate_rule`` runs once per rule per event, so the parsed-and-validated
+# tree is memoised. Failures are memoised too: without that, a single malformed
+# rule would be re-parsed on every event forever.
+_RULE_CACHE: Dict[str, Any] = {}
+_RULE_CACHE_MAX_ENTRIES = 1024
+
+
+def _parse_and_validate(expression: str) -> ast.Expression:
+    if len(expression) > MAX_EXPRESSION_LENGTH:
+        raise RuleTooComplexError(f"rule is longer than {MAX_EXPRESSION_LENGTH} characters")
+
+    tree = ast.parse(expression, mode="eval")
+    _validate(tree.body, _Budget(MAX_AST_NODES))
+    return tree
+
+
+def _compile_rule(expression: str) -> ast.Expression:
+    """Return the validated AST for ``expression``, parsing it at most once."""
+    cached = _RULE_CACHE.get(expression)
+    if cached is not None:
+        if isinstance(cached, Exception):
+            # Drop the accumulated traceback so re-raising a memoised failure
+            # does not grow without bound.
+            raise cached.with_traceback(None)
+        return cached
+
+    try:
+        compiled = _parse_and_validate(expression)
+    except Exception as error:
+        if len(_RULE_CACHE) < _RULE_CACHE_MAX_ENTRIES:
+            _RULE_CACHE[expression] = error
+        raise
+
+    if len(_RULE_CACHE) < _RULE_CACHE_MAX_ENTRIES:
+        _RULE_CACHE[expression] = compiled
+    return compiled
+
+
+def evaluate_rule(
+    expression: str, event: Dict[str, Any]
+) -> Any:  # noqa: ANN401 (a rule may return any value; the caller requires ``is True``)
+    """Evaluate a rule ``expression`` with ``event`` bound to the flattened event.
+
+    Raises :class:`SyntaxError` for a malformed expression, :class:`NameError`
+    for an unknown name, :class:`RuleEvaluationError` for syntax outside the
+    allowed grammar, and whatever the expression itself raises (for example
+    ``KeyError`` for a missing key) - matching how the previous ``eval``-based
+    implementation surfaced rule problems.
+    """
+    tree = _compile_rule(expression)
+    return _RuleEvaluator({"event": event}).evaluate(tree.body)

--- a/src/tests/test_rule_evaluator.py
+++ b/src/tests/test_rule_evaluator.py
@@ -1,0 +1,272 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for the restricted rule evaluator that replaced ``eval()`` (CWE-94)."""
+
+import pytest
+from rule_evaluator import (
+    _RULE_CACHE,
+    MAX_AST_NODES,
+    MAX_EXPRESSION_LENGTH,
+    MAX_NESTING_DEPTH,
+    RuleTooComplexError,
+    UnsupportedRuleError,
+    evaluate_rule,
+)
+
+# ruff: noqa: ANN201, ANN001, E501
+
+FLAT_EVENT = {
+    "eventName": "ConsoleLogin",
+    "eventSource": "signin.amazonaws.com",
+    "userIdentity.type": "IAMUser",
+    "userIdentity.arn": "arn:aws:iam::111111111111:user/alice",
+    "userIdentity.accountId": "111111111111",
+    "additionalEventData.MFAUsed": "No",
+    "errorCode": "AccessDenied",
+    "responseElements.functionName": "fivexl-cloudtrail-to-slack",
+    "requestParameters.instanceCount": 3,
+}
+
+
+# --- supported grammar: everything the documented rules rely on --------------
+
+
+@pytest.mark.parametrize(
+    ("expression", "expected"),
+    [
+        # subscript + equality
+        ('event["eventName"] == "ConsoleLogin"', True),
+        ('event["eventName"] == "AssumeRole"', False),
+        # dict.get with a default
+        ('event.get("additionalEventData.MFAUsed", "") != "Yes"', True),
+        ('event.get("does.not.exist", "") != ""', False),
+        # str.startswith / str.endswith, including the tuple form
+        ('event.get("errorCode", "").startswith(("AccessDenied"))', True),
+        ('event.get("errorCode", "").endswith(("UnauthorizedOperation"))', False),
+        ('not event["eventName"].startswith(("Get", "List", "Describe", "Head"))', True),
+        # membership
+        ('"userIdentity.accountId" in event', True),
+        ('"nope" in event', False),
+        ('"assumed-role/AWSReservedSSO" not in event.get("userIdentity.arn", "")', True),
+        ('event["eventName"] in ["ConsoleLogin", "AssumeRole"]', True),
+        ('event["eventName"] in {"ConsoleLogin", "AssumeRole"}', True),
+        ('event["eventName"] in ("Nope",)', False),
+        # boolean composition and parentheses
+        (
+            'event["eventName"] == "ConsoleLogin" '
+            'and event.get("additionalEventData.MFAUsed", "") != "Yes" '
+            'and "assumed-role/AWSReservedSSO" not in event.get("userIdentity.arn", "")',
+            True,
+        ),
+        ('event["eventName"] == "Nope" or event["eventSource"] == "signin.amazonaws.com"', True),
+        (
+            '(event.get("errorCode", "").startswith(("AccessDenied"))) '
+            'and (event.get("userIdentity.accountId", "") != "ANONYMOUS_PRINCIPAL")',
+            True,
+        ),
+        # allowed builtins, arithmetic, chained comparison, ternary
+        ('len(event["userIdentity.accountId"]) == 12', True),
+        ('1 < event["requestParameters.instanceCount"] <= 5', True),
+        ('str(event["requestParameters.instanceCount"]) == "3"', True),
+        ('event["requestParameters.instanceCount"] + 1 == 4', True),
+        ('"a" if event["eventName"] == "ConsoleLogin" else "b"', "a"),
+        ('event["userIdentity.type"].lower() == "iamuser"', True),
+        ('event["userIdentity.arn"][:12] == "arn:aws:iam:"', True),
+        ('event["userIdentity.accountId"][-4:] == "1111"', True),
+        ('any([event["eventName"] == "ConsoleLogin", False])', True),
+    ],
+)
+def test_supported_expressions(expression, expected):
+    assert evaluate_rule(expression, FLAT_EVENT) == expected
+
+
+def test_default_rules_still_evaluate():
+    """Every shipped default rule must evaluate under the restricted grammar."""
+    from rules import default_rules
+
+    for rule in default_rules:
+        assert evaluate_rule(rule, FLAT_EVENT) in (True, False)
+
+
+def test_events_to_track_rule_shape():
+    """The generated ``events_to_track`` rule from config.py must still work."""
+    rule = '"eventName" in event and event["eventName"] in ["ConsoleLogin", "SendSSHPublicKey"]'
+    assert evaluate_rule(rule, FLAT_EVENT) is True
+
+
+# --- the vulnerability: code execution must no longer be reachable ----------
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        # The exact payload class called out by CWE-94 / Inspector.
+        '__import__("os").system("id")',
+        '__import__("subprocess").check_output(["id"])',
+        # ``eval`` with empty globals still exposed these.
+        'eval("1+1")',
+        'exec("x=1")',
+        'open("/etc/passwd").read()',
+        "globals()",
+        "locals()",
+        'getattr(event, "keys")()',
+        # Object-graph traversal to reach a subprocess primitive.
+        "().__class__.__bases__[0].__subclasses__()",
+        'event.__class__.__init__.__globals__["__builtins__"]',
+        "event.__setitem__",
+        # Attribute access that is not an allow-listed method call.
+        "event.keys",
+        "event.keys().mapping",
+        'event["eventName"].encode',
+        # A dangerous callable cannot be smuggled in as a keyword argument.
+        "sorted(event, key=eval)",
+        "sorted(event, key=__import__)",
+        # An unbound method cannot be reached by smuggling a type into the
+        # receiver position through a literal or a dict.get default.
+        '[str][0].upper("a")',
+        '{"s": str}["s"].upper("a")',
+        '(str,)[0].join(",", ["a"])',
+        'event.get("nope", str).upper("a")',
+        'str.join(",", event.keys())',
+        'event.get("nope", len)("abc")',
+        '{"f": len}["f"]("abc")',
+        # Non-allow-listed method names.
+        '"{0.__class__}".format(event)',
+        'event["eventName"].__str__()',
+        # Statements / assignment / walrus are not expressions we accept.
+        "[x for x in event]",
+        "(x for x in event)",
+        "lambda: 1",
+        "{k: v for k, v in event.items()}",
+        "10 ** 10 ** 10",
+        'f"{event}"',
+        'event["eventName"] if (y := 1) else "b"',
+    ],
+)
+def test_dangerous_expressions_are_rejected(expression):
+    with pytest.raises((UnsupportedRuleError, NameError, SyntaxError)):
+        evaluate_rule(expression, FLAT_EVENT)
+
+
+def test_no_module_can_be_reached_via_builtins():
+    """Sanity check that the builtins we do expose cannot import or open."""
+    for name in ("__import__", "compile", "eval", "exec", "open", "getattr", "setattr", "vars", "dir", "type", "input", "breakpoint"):
+        with pytest.raises((UnsupportedRuleError, NameError)):
+            evaluate_rule(f'{name}("x")', FLAT_EVENT)
+
+
+# --- error behaviour expected by main.py's rule-error reporting -------------
+
+
+def test_unknown_name_raises_nameerror_like_eval():
+    with pytest.raises(NameError) as excinfo:
+        evaluate_rule("incorrect_rule", FLAT_EVENT)
+    assert str(excinfo.value) == "name 'incorrect_rule' is not defined"
+
+
+def test_malformed_rule_raises_syntaxerror():
+    with pytest.raises(SyntaxError):
+        evaluate_rule('event["eventName" == ', FLAT_EVENT)
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        '"a" < "b"',
+        "1 == 1",
+        "1 < 2 < 3",
+        "3 < 2 < 1",
+        "1 < 2 < 3 == 3 != 4",
+        'event["eventName"] == "ConsoleLogin" and event["eventSource"]',
+        'event["eventName"] == "Nope" or event["eventSource"]',
+        '"" or event["eventName"]',
+        '"x" and 0',
+        'not event["eventName"]',
+        'event["requestParameters.instanceCount"] % 2',
+        'event["requestParameters.instanceCount"] - 4',
+        'len(event["eventName"]) // 3',
+        '"ConsoleLogin" in event["eventName"][0:12]',
+    ],
+)
+def test_result_matches_builtin_eval_for_safe_expressions(expression):
+    """The restricted evaluator must not change the value a rule produces."""
+    expected = eval(expression, {"__builtins__": {"len": len}}, {"event": FLAT_EVENT})  # noqa: PGH001, S307
+    actual = evaluate_rule(expression, FLAT_EVENT)
+    assert actual == expected
+    assert type(actual) is type(expected)
+
+
+def test_missing_key_still_raises_keyerror():
+    with pytest.raises(KeyError):
+        evaluate_rule('event["not.there"] == "x"', FLAT_EVENT)
+
+
+# --- resource guard rails ---------------------------------------------------
+
+
+def test_over_long_rule_is_rejected():
+    with pytest.raises(RuleTooComplexError):
+        evaluate_rule('event["eventName"] == "' + "x" * MAX_EXPRESSION_LENGTH + '"', FLAT_EVENT)
+
+
+def test_over_complex_rule_is_rejected():
+    expression = " or ".join(['event["eventName"] == "x"'] * MAX_AST_NODES)
+    with pytest.raises(RuleTooComplexError):
+        evaluate_rule(expression, FLAT_EVENT)
+
+
+def test_deeply_nested_rule_is_rejected_before_recursion_error():
+    """A deep tree must fail as RuleTooComplexError, not RecursionError."""
+    expression = "not " * (MAX_NESTING_DEPTH + 10) + "True"
+    with pytest.raises(RuleTooComplexError):
+        evaluate_rule(expression, FLAT_EVENT)
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        # Sequence repetition can allocate gigabytes from a tiny rule, and an
+        # out-of-memory kill is not catchable per-rule the way an error is.
+        '"a" * 300000000',
+        "[0] * 100000000000",
+        '"a".join(["b"] * 2000000000)',
+        "10 ** 10 ** 10",
+    ],
+)
+def test_resource_exhaustion_operators_are_rejected(expression):
+    with pytest.raises(UnsupportedRuleError):
+        evaluate_rule(expression, FLAT_EVENT)
+
+
+def test_generated_events_to_track_rule_is_not_length_limited():
+    """config.py folds the whole events_to_track list into one expression."""
+    import json
+
+    previous_limit = 4096  # the limit before it was raised for this exact case
+    events = [f"SomeLongishApiCallName{index}" for index in range(200)]
+    rule = f'"eventName" in event and event["eventName"] in {json.dumps(events)}'
+    assert len(rule) > previous_limit
+    assert evaluate_rule(rule, FLAT_EVENT) is False
+
+
+def test_a_failing_rule_is_only_parsed_once():
+    """A rule that fails validation must not be re-parsed for every event."""
+    expression = f"[x for x in event]  # {id(object())}"
+    for _ in range(3):
+        with pytest.raises(UnsupportedRuleError):
+            evaluate_rule(expression, FLAT_EVENT)
+    assert isinstance(_RULE_CACHE[expression], UnsupportedRuleError)


### PR DESCRIPTION
## Problem

Amazon Inspector reports five findings against the deployed `fivexl-cloudtrail-to-slack` Lambda:

| Finding | Severity | Where |
| --- | --- | --- |
| **CWE-94** — unsanitized input is run as code | **CRITICAL** | `src/main.py:186` and `:197` |
| **CVE-2026-7246** — command injection in `click.edit()` | HIGH | `click` 8.1.8 |
| **CVE-2025-66418** — unbounded decompression chain | HIGH | `urllib3` 2.3.0 |
| **CVE-2025-66471** — decompression bomb via streaming API | HIGH | `urllib3` 2.3.0 |
| **CVE-2026-21441** — decompression bomb on redirect responses | HIGH | `urllib3` 2.3.0 |

## Why it matters

**CWE-94 is the substantive one.** Rules are operator-supplied Python expressions read from the `RULES` / `IGNORE_RULES` Lambda environment variables and handed straight to `eval()`. Passing empty globals does not sandbox anything — CPython injects `__builtins__` automatically, so `__import__("os").system(...)` was reachable from anything able to influence the function's configuration (a compromised CI pipeline, an over-broad `lambda:UpdateFunctionConfiguration` grant, or a Terraform variable sourced from user input). The function holds `s3:GetObject` on the CloudTrail bucket, `dynamodb:*Item`, `cloudwatch:PutMetricData`, `sns:Publish` and the Slack bot token.

The three dependency CVEs are lower impact and worth stating plainly: `click` and `urllib3` are **dev-group transitives** (via `black` and `botocore`) and were never installed into the Lambda — only `src/deploy_requirements.txt` (`slack-sdk`) is. They are attributed to the function because `requirements.txt` and `poetry.lock` ship *inside* the deployment package, so Inspector reads them as the function's manifest. Fixing them is lockfile hygiene plus removing the false attribution, not a live runtime exposure.

## Fix

### `eval()` to a restricted AST evaluator (`src/rule_evaluator.py`)

Rules are parsed with `ast` and walked with an explicit **allow-list** of node types, operators, builtins and method names. The property that makes it hold: `ast.Attribute` is absent from the handler table, so an attribute is only ever reachable as the **callee of a call to an allow-listed method**, and `_validate_call` requires `Call.func` to be either a `Name` bound to one of 13 pure builtins or an `Attribute` whose name is in a 30-entry method allow-list. There is no path that turns an expression value into a callable target, so `__class__`, `__globals__`, `__subclasses__`, `__import__`, `open` and `getattr` are all unreachable.

Additional hardening from review:

- `**` **and** `*` are rejected. `**` was the obvious `10 ** 10 ** 10` timeout burner, but `"a" * 300000000` is a 17-character rule that allocates 300 MB — well past the default `lambda_memory_size` of 256 — and an out-of-memory termination ends the process rather than raising, so it is the one failure the per-rule `except Exception` cannot report.
- A callable or type receiver is refused, so an unbound method cannot be smuggled into the receiver position (`[str][0].upper("a")`). Defence in depth: it means adding a name to the method allow-list later cannot accidentally widen the sandbox.
- Length (65536 chars), size (2000 elements) and **nesting depth** (100 levels) limits. The depth limit is the one that matters — evaluation recurses per level, and without it a deep tree surfaced as `RecursionError` instead of the intended error.
- The length limit is deliberately generous because `src/config.py` folds an entire `events_to_track` list into a single expression; a tighter limit would break that documented path for large lists.
- Parse results **and** validation failures are memoised, so a malformed rule is not re-parsed on every event.

Error behaviour is preserved exactly: an unknown name still raises `NameError("name 'x' is not defined")` (asserted by the pre-existing `test_message_processing.py`), and a bad rule is still collected per-rule and reported through `rule_evaluation_errors_to_slack` rather than failing the invocation.

### Dependencies

`click` to **8.4.2** (>= 8.3.3) and `urllib3` to **2.7.0** (>= 2.6.3, covers all three CVEs), pinned as explicit dev constraints in `src/pyproject.toml` and re-locked. `src/requirements.txt` was regenerated with `poetry export --with dev` exactly as the repo's pre-commit hook does. No other package version moved. `src/deploy_requirements.txt` — what actually ships — is untouched.

### Packaging

`pyproject.toml`, `poetry.lock`, `requirements.txt` and `.ruff_cache/` are excluded from the Lambda zip. Only `deploy_requirements.txt` is installed at build time, and it is read from disk by path rather than from the archive, so the build is unaffected. This is what stops a scanner reporting the dev tool chain as the function's runtime dependencies.

## Breaking change (documented in the README)

The rule grammar is now an explicit subset of Python rather than "whatever `eval` accepts". **Every rule this module ships or documents works unchanged** — I checked the full history of `README.md`, `src/rules.py`, `examples/` and `docs/`; all of them use only subscripts, `.get`, `.startswith` / `.endswith`, `in`, `and` and `not`.

A custom rule using comprehensions, generator expressions (`any(k.startswith("x") for k in event.keys())`), f-strings, `.format()`, `isinstance()`, `lambda`, `:=`, `**`, `*` or the bitwise operators will now be rejected with a rule evaluation error (delivered to Slack by default) instead of silently evaluating. The README documents the supported grammar and the rejected constructs. If generator support inside `any()` / `all()` turns out to be wanted, it can be added as a bounded follow-up.

## Tests

`src/tests/test_rule_evaluator.py` — **86 new cases**, suite goes 25 to 111 passing:

- every documented rule shape, plus the generated `events_to_track` and `rules` forms from `config.py`
- all shipped `default_rules` evaluate under the restricted grammar
- ~30 escape payloads asserted rejected: `__import__`, `eval` / `exec` / `open` / `getattr`, `().__class__.__bases__[0].__subclasses__()`, `__globals__["__builtins__"]`, `"{0.__class__}".format(...)`, callables smuggled through keyword args and container literals, unbound methods via a type in the receiver position, comprehensions, `lambda`, f-strings, `:=`
- resource-exhaustion payloads (`"a" * 300000000`, `[0] * 100000000000`, `10 ** 10 ** 10`, deep nesting) rejected rather than executed
- **parity against builtin `eval()`** on safe expressions, including `and` / `or` short-circuit *return values* and chained comparisons, asserting both value and type

## Manual verification

- `pytest src` to 111 passed
- `ruff check $(git ls-files '*.py')` (what CI runs) — clean
- `black --check` on the new and changed Python files (project's 26.5.1, line-length 140) — clean
- `terraform fmt -check -recursive` and `terraform validate` — clean
- Reimplemented `ZipContentFilter` from `terraform-aws-modules/lambda` v8.8.0 `package.py` (`re.fullmatch` on the source-relative path) and ran it over the real `src/` tree: the three manifests and `.ruff_cache/` are excluded, `deploy_requirements.txt` **is** included (`fullmatch` anchors both ends, so `!requirements\.txt` cannot match it), and every runtime module is included.
- Verified both new package versions exist on PyPI, are not yanked, that every `--hash` in `requirements.txt` matches the PyPI sha256 and appears in the lockfile, and that `poetry.lock`'s `content-hash` matches the edited `pyproject.toml` (lock is not stale).
- No AWS resources were created, modified or read; `terraform validate` ran with `-backend=false`.

Screenshots: N/A — no user-visible UI in this module.

---

Built with KiroCrew, and reviewed by two independent KiroCrew sub-agents: a security escape review that ran ~110 adversarial payloads and found no escape, and a backwards-compatibility, dependency and Terraform review. Every finding they raised is addressed in this commit.
